### PR TITLE
Email Verifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 sudo: false
 language: ruby
+services:
+  - redis-server
 rvm:
-- 2.3.1
+  - 2.3.3
 before_install: gem install bundler -v 1.12.5
 deploy:
   provider: rubygems

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM ruby:2.3.3-alpine
 ENV AUTHIFY_PORT=9292
 ENV AUTHIFY_ENVIRONMENT=development
 ENV AUTHIFY_DB_URL=sqlite3:///app/authify-api.db
+ENV AUTHIFY_REDIS_HOST=redis
 ENV AUTHIFY_PUBKEY_PATH=/ssl/public.pem
 ENV AUTHIFY_PRIVKEY_PATH=/ssl/private.pem
 ENV AUTHIFY_JWT_ISSUER="My Awesome Company Inc."

--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ end
 RSpec::Core::RakeTask.new(:spec)
 RuboCop::RakeTask.new(:rubocop)
 
-task default: [:spec, :rubocop]
+task default: %i(spec rubocop)
 
 desc 'Start the demo using `rackup`'
 task :start do

--- a/authify-api.gemspec
+++ b/authify-api.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'authify/api/version'

--- a/authify-api.gemspec
+++ b/authify-api.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '~> 2.0'
 
-  spec.add_runtime_dependency 'authify-core'
+  spec.add_runtime_dependency 'authify-core', '~> 0.1'
   spec.add_runtime_dependency 'authify-middleware'
   spec.add_runtime_dependency 'connection_pool', '~> 2.2'
   spec.add_runtime_dependency 'sinatra', '>= 2.0.0.beta2', '< 3'
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'jsonapi-serializers', '~> 0.16'
   # spec.add_runtime_dependency 'sinja', '~> 1.2', '>= 1.2.4'
   spec.add_runtime_dependency 'puma', '~> 3.7'
+  spec.add_runtime_dependency 'resque', '~> 1.26'
 
   spec.add_development_dependency 'bundler', '~> 1.12'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/db/migrate/20170328151033_add_verified_to_user.rb
+++ b/db/migrate/20170328151033_add_verified_to_user.rb
@@ -1,0 +1,10 @@
+# User verifications
+class AddVerifiedToUser < ActiveRecord::Migration[5.0]
+  def change
+    change_table :users do |t|
+      t.boolean :verified
+      t.string :verification_token
+      t.index :verified
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170208022427) do
+ActiveRecord::Schema.define(version: 20170328151033) do
 
   create_table "apikeys", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "user_id"
@@ -85,13 +85,16 @@ ActiveRecord::Schema.define(version: 20170208022427) do
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "email"
-    t.text     "password_digest", limit: 65535
+    t.text     "password_digest",    limit: 65535
     t.string   "full_name"
-    t.datetime "created_at",                                    null: false
-    t.datetime "updated_at",                                    null: false
-    t.boolean  "admin",                         default: false, null: false
+    t.datetime "created_at",                                       null: false
+    t.datetime "updated_at",                                       null: false
+    t.boolean  "admin",                            default: false, null: false
+    t.boolean  "verified"
+    t.string   "verification_token"
     t.index ["admin"], name: "index_users_on_admin", using: :btree
     t.index ["email"], name: "index_users_on_email", using: :btree
+    t.index ["verified"], name: "index_users_on_verified", using: :btree
   end
 
 end

--- a/lib/authify/api.rb
+++ b/lib/authify/api.rb
@@ -2,6 +2,7 @@
 
 # External Requirements
 require 'authify/core'
+require 'authify/core/jobs/email'
 require 'authify/middleware'
 require 'sinatra/base'
 require 'sinatra/activerecord'
@@ -10,6 +11,7 @@ require 'sinatra/jsonapi'
 require 'tilt/erb'
 require 'connection_pool'
 require 'moneta'
+require 'resque'
 
 # Internal Requirements
 module Authify
@@ -25,6 +27,9 @@ module Authify
     )
   end
 end
+
+redis_config = Authify::API::CONFIG[:redis]
+Resque.redis = "#{redis_config[:host]}:#{redis_config[:port]}"
 
 require 'authify/api/version'
 require 'authify/api/jsonapi_utils'

--- a/lib/authify/api/controllers/apikey.rb
+++ b/lib/authify/api/controllers/apikey.rb
@@ -18,7 +18,7 @@ module Authify
           Models::APIKey.all
         end
 
-        show(roles: [:myself, :admin]) do
+        show(roles: %i(myself admin)) do
           last_modified resource.updated_at
           next resource, exclude: [:secret_key]
         end
@@ -31,7 +31,7 @@ module Authify
           next key.id, key
         end
 
-        destroy(roles: [:myself, :admin]) do
+        destroy(roles: %i(myself admin)) do
           resource.destroy
         end
 
@@ -40,7 +40,7 @@ module Authify
         end
 
         has_one :user do
-          pluck(roles: [:myself, :admin]) do
+          pluck(roles: %i(myself admin)) do
             resource.user
           end
         end

--- a/lib/authify/api/controllers/group.rb
+++ b/lib/authify/api/controllers/group.rb
@@ -19,7 +19,7 @@ module Authify
           Models::Group.all
         end
 
-        show(roles: [:admin, :owner]) do
+        show(roles: %i(admin owner)) do
           last_modified resource.updated_at
           next resource
         end
@@ -30,7 +30,7 @@ module Authify
           next g
         end
 
-        destroy(roles: [:admin, :owner]) do
+        destroy(roles: %i(admin owner)) do
           resource.destroy
         end
 
@@ -39,23 +39,23 @@ module Authify
         end
 
         has_many :users do
-          fetch(roles: [:admin, :owner]) do
+          fetch(roles: %i(admin owner)) do
             resource.users
           end
 
-          replace(roles: [:admin, :owner]) do |rios|
+          replace(roles: %i(admin owner)) do |rios|
             refs = rios.map { |attrs| Models::User.find(attrs) }
             resource.users = refs
             resource.save
           end
 
-          merge(roles: [:admin, :owner]) do |rios|
+          merge(roles: %i(admin owner)) do |rios|
             refs = rios.map { |attrs| Models::User.find(attrs) }
             resource.users << refs
             resource.save
           end
 
-          subtract(roles: [:admin, :owner]) do |rios|
+          subtract(roles: %i(admin owner)) do |rios|
             refs = rios.map { |attrs| Models::User.find(attrs) }
             # This only removes the linkage, not the actual users
             resource.users.delete(refs)

--- a/lib/authify/api/controllers/identity.rb
+++ b/lib/authify/api/controllers/identity.rb
@@ -14,11 +14,11 @@ module Authify
           end
         end
 
-        index(roles: [:admin, :trusted]) do
+        index(roles: %i(admin trusted)) do
           Models::Identity.all
         end
 
-        show(roles: [:myself, :admin, :trusted]) do
+        show(roles: %i(myself admin trusted)) do
           last_modified resource.updated_at
           next resource
         end
@@ -30,7 +30,7 @@ module Authify
           next ident.id, ident
         end
 
-        destroy(roles: [:myself, :admin]) do
+        destroy(roles: %i(myself admin)) do
           resource.destroy
         end
 
@@ -39,7 +39,7 @@ module Authify
         end
 
         has_one :user do
-          pluck(roles: [:myself, :admin, :trusted]) do
+          pluck(roles: %i(myself admin trusted)) do
             resource.user
           end
         end

--- a/lib/authify/api/controllers/organization.rb
+++ b/lib/authify/api/controllers/organization.rb
@@ -15,15 +15,15 @@ module Authify
           end
 
           def modifiable_fields
-            [
-              :name,
-              :public_email,
-              :gravatar_email,
-              :billing_email,
-              :description,
-              :url,
-              :location
-            ]
+            %i(
+              name
+              public_email
+              gravatar_email
+              billing_email
+              description
+              url
+              location
+            )
           end
 
           def filtered_attributes(attributes)
@@ -41,7 +41,7 @@ module Authify
           end
         end
 
-        index(roles: [:admin, :user]) do
+        index(roles: %i(admin user)) do
           Models::Organization.includes(:users, :groups, :admins)
         end
 
@@ -72,29 +72,29 @@ module Authify
           next o.id, o
         end
 
-        update(roles: [:owner, :admin]) do |attrs|
+        update(roles: %i(owner admin)) do |attrs|
           resource.update filtered_attributes(attrs)
           next resource
         end
 
-        destroy(roles: [:owner, :admin]) do
+        destroy(roles: %i(owner admin)) do
           resource.destroy
         end
 
         has_many :users do
-          fetch(roles: [:owner, :admin, :member]) do
+          fetch(roles: %i(owner admin member)) do
             resource.users
           end
         end
 
         has_many :admins do
-          fetch(roles: [:owner, :admin, :member]) do
+          fetch(roles: %i(owner admin member)) do
             resource.admins
           end
         end
 
         has_many :groups do
-          fetch(roles: [:owner, :admin, :member]) do
+          fetch(roles: %i(owner admin member)) do
             resource.groups
           end
         end

--- a/lib/authify/api/controllers/user.rb
+++ b/lib/authify/api/controllers/user.rb
@@ -14,7 +14,7 @@ module Authify
           end
 
           def modifiable_fields
-            [:full_name, :email].tap do |a|
+            %i(full_name email).tap do |a|
               a << :admin if role.include?(:admin)
             end
           end
@@ -34,11 +34,11 @@ module Authify
           end
         end
 
-        index(roles: [:user, :trusted]) do
+        index(roles: %i(user trusted)) do
           Models::User.all
         end
 
-        show(roles: [:user, :trusted]) do
+        show(roles: %i(user trusted)) do
           last_modified resource.updated_at
           next resource
         end
@@ -49,7 +49,7 @@ module Authify
           next user
         end
 
-        update(roles: [:admin, :myself]) do |attrs|
+        update(roles: %i(admin myself)) do |attrs|
           # Necessary because #password= is overridden for Models::User
           new_pass = attrs[:password] if attrs && attrs.key?(:password)
           resource.update filtered_attributes(attrs)
@@ -63,16 +63,16 @@ module Authify
         end
 
         has_many :apikeys do
-          fetch(roles: [:myself, :admin]) do
+          fetch(roles: %i(myself admin)) do
             resource.apikeys
           end
 
-          clear(roles: [:myself, :admin]) do
+          clear(roles: %i(myself admin)) do
             resource.apikeys.destroy_all
             resource.save
           end
 
-          subtract(roles: [:myself, :admin]) do |rios|
+          subtract(roles: %i(myself admin)) do |rios|
             refs = rios.map { |attrs| Models::APIKey.find(attrs) }
             # This actually calls #destroy on the keys (we don't need orphaned keys)
             resource.apikeys.destroy(refs)
@@ -81,11 +81,11 @@ module Authify
         end
 
         has_many :identities do
-          fetch(roles: [:myself, :admin, :trusted]) do
+          fetch(roles: %i(myself admin trusted)) do
             resource.identities
           end
 
-          clear(roles: [:myself, :admin]) do
+          clear(roles: %i(myself admin)) do
             resource.identities.destroy_all
             resource.save
           end
@@ -96,7 +96,7 @@ module Authify
             resource.save
           end
 
-          subtract(roles: [:myself, :admin]) do |rios|
+          subtract(roles: %i(myself admin)) do |rios|
             refs = rios.map { |attrs| Models::Identity.find(attrs) }
             resource.identities.destroy(refs)
             resource.save
@@ -104,13 +104,13 @@ module Authify
         end
 
         has_many :organizations do
-          fetch(roles: [:user, :myself, :admin]) do
+          fetch(roles: %i(user myself admin)) do
             resource.organizations
           end
         end
 
         has_many :groups do
-          fetch(roles: [:myself, :admin]) do
+          fetch(roles: %i(myself admin)) do
             resource.groups
           end
         end

--- a/lib/authify/api/models/user.rb
+++ b/lib/authify/api/models/user.rb
@@ -42,18 +42,43 @@ module Authify
           compare_salted_sha512(unencrypted_password, password_digest)
         end
 
+        def verify(vtoken)
+          return false unless verification_token
+          token, valid_until = verification_token.split(':')
+          token == vtoken && Time.now.to_i <= Integer(valid_until)
+        end
+
+        # Both sets a token in the DB *and* emails it to the user
+        def set_verification_token!
+          return false if verified?
+          token = peppered_sha512(rand(999).to_s)[0...16]
+          valid_until = (Time.now + (15 * 60)).to_i
+          self.verification_token = "#{token}:#{valid_until}"
+
+          email_opts = {
+            body: "Your verification token is: #{token}"
+          }
+
+          Resque.enqueue(
+            Authify::Core::Jobs::Email,
+            email,
+            'Authify Verification Email',
+            email_opts
+          )
+        end
+
         def admin_for?(organization)
           admin? || organization.admins.include?(self)
         end
 
         def self.from_api_key(access, secret)
           key = APIKey.find_by_access_key(access)
-          key.user if key && key.compare_secret(secret)
+          key.user if key && key.compare_secret(secret) && key.user.verified?
         end
 
         def self.from_email(email, password)
           found_user = Models::User.find_by_email(email)
-          found_user if found_user && found_user.authenticate(password)
+          found_user if found_user && found_user.authenticate(password) && found_user.verified?
         end
 
         def self.from_identity(provider, uid)

--- a/lib/authify/api/serializers/user_serializer.rb
+++ b/lib/authify/api/serializers/user_serializer.rb
@@ -9,6 +9,7 @@ module Authify
         attribute :full_name
         attribute :admin
         attribute :created_at
+        attribute :verified
 
         has_many :apikeys
         has_many :groups

--- a/lib/authify/api/services/jwt_provider.rb
+++ b/lib/authify/api/services/jwt_provider.rb
@@ -36,19 +36,12 @@ module Authify
           email = @parsed_body[:email]
           password = @parsed_body[:password]
           # For Trusted Delegates signing users in via omniauth
-          del_data = @parsed_body[:delegate]
           omni_provider = @parsed_body[:provider]
           omni_uid = @parsed_body[:uid]
-          trusted_delegate = if del_data
-                               Models::TrustedDelegate.from_access_key(
-                                 del_data[:access],
-                                 del_data[:secret]
-                               )
-                             end
 
           found_user = if access
                          Models::User.from_api_key(access, secret)
-                       elsif trusted_delegate
+                       elsif remote_app
                          Models::User.from_identity(omni_provider, omni_uid)
                        elsif email
                          Models::User.from_email(email, password)

--- a/lib/authify/api/version.rb
+++ b/lib/authify/api/version.rb
@@ -2,7 +2,7 @@ module Authify
   module API
     VERSION = [
       0, # Major
-      1, # Minor
+      2, # Minor
       0  # Patch
     ].join('.')
   end

--- a/spec/authify/services/jwt_provider_spec.rb
+++ b/spec/authify/services/jwt_provider_spec.rb
@@ -79,10 +79,6 @@ describe Authify::API::Services::JWTProvider do
 
       let(:trusted_delegate_auth_data) do
         {
-          'delegate' => {
-            'access' => RSpec.configuration.trusted_delegate.access_key,
-            'secret' => RSpec.configuration.trusted_delegate.secret_key
-          },
           'provider' => RSpec.configuration.test_user_identity.provider,
           'uid' => RSpec.configuration.test_user_identity.uid
         }.to_json
@@ -136,6 +132,8 @@ describe Authify::API::Services::JWTProvider do
           it 'provides a usable JWT' do
             header 'Accept', 'application/json'
             header 'Content-Type', 'application/json'
+            header 'X-Authify-Access', RSpec.configuration.trusted_delegate.access_key
+            header 'X-Authify-Secret', RSpec.configuration.trusted_delegate.secret_key
             post '/token', trusted_delegate_auth_data
 
             # Should respond with a 200

--- a/spec/authify/services/registration_spec.rb
+++ b/spec/authify/services/registration_spec.rb
@@ -24,10 +24,6 @@ describe Authify::API::Services::Registration do
           'via' => {
             'provider' => 'facetube',
             'uid'      => '23456'
-          },
-          'delegate' => {
-            'access' => RSpec.configuration.trusted_delegate.access_key,
-            'secret' => RSpec.configuration.trusted_delegate.secret_key
           }
         }
       end
@@ -44,7 +40,8 @@ describe Authify::API::Services::Registration do
           details = JSON.parse(last_response.body)
 
           expect(details.size).to eq(3)
-          expect(details).to have_key('jwt')
+          expect(details).to have_key('verified')
+          expect(details['verified']).to be(false)
           expect(details['email']).to eq(password_signup_data['email'])
           expect(details['id']).to eq(4)
         end
@@ -52,6 +49,8 @@ describe Authify::API::Services::Registration do
         it 'allows registration via delegate and identity' do
           header 'Accept', 'application/json'
           header 'Content-Type', 'application/json'
+          header 'X-Authify-Access', RSpec.configuration.trusted_delegate.access_key
+          header 'X-Authify-Secret', RSpec.configuration.trusted_delegate.secret_key
           post '/signup', identity_signup_data.to_json
 
           # Should respond with a 200
@@ -59,7 +58,9 @@ describe Authify::API::Services::Registration do
 
           details = JSON.parse(last_response.body)
 
-          expect(details.size).to eq(3)
+          expect(details.size).to eq(4)
+          expect(details).to have_key('verified')
+          expect(details['verified']).to be(true)
           expect(details).to have_key('jwt')
           expect(details['email']).to eq(identity_signup_data['email'])
           expect(details['id']).to eq(5)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -68,6 +68,7 @@ RSpec.configure do |config|
     # Associate an identity with the user
     identity = Authify::API::Models::Identity.new(provider: 'facetube', uid: '12345')
     user.identities << identity
+    user.verified = true
     user.save
     RSpec.configuration.test_user = user
     RSpec.configuration.test_user_apikey = key


### PR DESCRIPTION
This adds a full-fledged dependency on Redis, which is now used for queuing (via Resque), specifically for sending emails. For now, these emails are limited to verification token emails.

This is just meant to start this feature; we can improve the contents of the email(s) later.

Updated tests to reflect new options, but we could use some tests specific to verifying from the token. Could probably also use a means to set the contents of the email via the API (so Authify::Web can send pretty HTML with links back to it).