### PR TITLE
Allowing custom payload data

### DIFF
--- a/lib/authify/api/helpers/jwt_encryption.rb
+++ b/lib/authify/api/helpers/jwt_encryption.rb
@@ -5,13 +5,13 @@ module Authify
       module JWTEncryption
         include Core::Helpers::JWTSSL
 
-        def jwt_token(user = nil)
+        def jwt_token(user: nil, custom_data: {})
           user ||= current_user
-          JWT.encode jwt_payload(user), private_key, CONFIG[:jwt][:algorithm]
+          JWT.encode jwt_payload(user, custom_data), private_key, CONFIG[:jwt][:algorithm]
         end
 
-        def jwt_payload(user)
-          {
+        def jwt_payload(user, custom_data)
+          data = {
             exp: Time.now.to_i + 60 * CONFIG[:jwt][:expiration].to_i,
             iat: Time.now.to_i,
             iss: CONFIG[:jwt][:issuer],
@@ -24,6 +24,8 @@ module Authify
               organizations: simple_orgs_by_user(user)
             }
           }
+          data[:custom] = custom_data if custom_data && !custom_data.empty?
+          data
         end
 
         def simple_orgs_by_user(user)

--- a/lib/authify/api/services/jwt_provider.rb
+++ b/lib/authify/api/services/jwt_provider.rb
@@ -38,6 +38,8 @@ module Authify
           # For Trusted Delegates signing users in via omniauth
           omni_provider = @parsed_body[:provider]
           omni_uid = @parsed_body[:uid]
+          # Allows injecting custom payload data
+          custom_data = @parsed_body[:inject] || {}
 
           found_user = if access
                          Models::User.from_api_key(access, secret)
@@ -49,7 +51,7 @@ module Authify
 
           if found_user
             update_current_user found_user
-            { jwt: jwt_token }.to_json
+            { jwt: jwt_token(custom_data: custom_data) }.to_json
           else
             halt 401
           end

--- a/lib/authify/api/services/registration.rb
+++ b/lib/authify/api/services/registration.rb
@@ -56,7 +56,7 @@ module Authify
           response = { id: new_user.id, email: new_user.email }
           if new_user.verified?
             response[:verified] = true
-            response[:jwt]      = jwt_token(new_user)
+            response[:jwt]      = jwt_token(user: new_user)
           else
             response[:verified] = false
           end
@@ -78,7 +78,7 @@ module Authify
               id: found_user.id,
               email: found_user.email,
               verified: found_user.verified?,
-              jwt: jwt_token(found_user)
+              jwt: jwt_token(user: found_user)
             }.to_json
           else
             found_user.verified = false
@@ -109,7 +109,7 @@ module Authify
             id: found_user.id,
             email: found_user.email,
             verified: found_user.verified?,
-            jwt: jwt_token(found_user)
+            jwt: jwt_token(user: found_user)
           }.to_json
         end
       end

--- a/lib/authify/api/version.rb
+++ b/lib/authify/api/version.rb
@@ -3,7 +3,7 @@ module Authify
     VERSION = [
       0, # Major
       3, # Minor
-      0  # Patch
+      1  # Patch
     ].join('.')
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -123,13 +123,13 @@ RSpec.configure do |config|
     RSpec.configuration.group = group
 
     # A user JWT for authentication
-    RSpec.configuration.test_user_token = jwt_token(user)
+    RSpec.configuration.test_user_token = jwt_token(user: user)
 
     # A user JWT for authentication
-    RSpec.configuration.bad_user_token = jwt_token(bad_user)
+    RSpec.configuration.bad_user_token = jwt_token(user: bad_user)
 
     # An admin JWT for authentication
-    RSpec.configuration.admin_user_token = jwt_token(admin_user)
+    RSpec.configuration.admin_user_token = jwt_token(user: admin_user)
   end
 
   config.after(:suite) do


### PR DESCRIPTION
Addressing #5 through an optional `inject` key on the POST data for `/jwt/token`.