### PR TITLE
Improving metrics

### DIFF
--- a/lib/authify/api/version.rb
+++ b/lib/authify/api/version.rb
@@ -3,7 +3,7 @@ module Authify
     VERSION = [
       0, # Major
       3, # Minor
-      1  # Patch
+      2  # Patch
     ].join('.')
   end
 end


### PR DESCRIPTION
Making the automatic detection of URI paths with IDs in them (like `/users/3` being `/users/:id`, then becoming `users.:id`) for metrics keys work better.