### PR TITLE
Removing the email field from most /user endpoints

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,9 @@ Metrics/LineLength:
 Metrics/ClassLength:
   Max: 150
 
+Metrics/ModuleLength:
+  Max: 150
+
 Metrics/AbcSize:
   Max: 22
 

--- a/lib/authify/api.rb
+++ b/lib/authify/api.rb
@@ -1,5 +1,4 @@
 # Standard Library Requirements
-require 'ostruct'
 
 # External Requirements
 require 'authify/core'

--- a/lib/authify/api.rb
+++ b/lib/authify/api.rb
@@ -1,4 +1,5 @@
 # Standard Library Requirements
+require 'ostruct'
 
 # External Requirements
 require 'authify/core'

--- a/lib/authify/api/controllers/user.rb
+++ b/lib/authify/api/controllers/user.rb
@@ -91,7 +91,7 @@ module Authify
         end
 
         show_many do |ids|
-          serialize_models Models::User.find(ids), fields: { users: indexable_fields }
+          Models::User.find(ids)
         end
 
         has_many :apikeys do


### PR DESCRIPTION
This should address #17 and provides a good example of selectively displaying fields in the future. Includes a few additional tests to verify `email` is only displayed when it should be. This should be fully compatible with work done towards #4 in the future.