### PR TITLE
Providing a way to not enforce email verifications

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ENV AUTHIFY_PRIVKEY_PATH=/ssl/private.pem
 ENV AUTHIFY_JWT_ISSUER="My Awesome Company Inc."
 ENV AUTHIFY_JWT_ALGORITHM="ES512"
 ENV AUTHIFY_JWT_EXPIRATION="15"
+ENV AUTHIFY_VERIFICATIONS_REQUIRED="true"
 
 RUN apk --no-cache upgrade \
     && apk --no-cache add \

--- a/README.md
+++ b/README.md
@@ -145,6 +145,9 @@ The name of the [JWA](https://tools.ietf.org/html/draft-ietf-jose-json-web-algor
 **`AUTHIFY_JWT_EXPIRATION`**
 How long should a JWT be valid (in minutes). Defaults to 15. Too small of a value will mean a lot more requests to the API; too high increases the possibility of viable keys being captured.
 
+**`AUTHIFY_VERIFICATIONS_REQUIRED`**
+Allows disabling the requirement for email verifications for user signups. **NOT RECOMMENDED FOR PRODUCTION!** This should be used only if public signups are disabled (which is not yet implemented) or for integration testing. Simply set this environment variable to `'false'` (as a string) and Authify will not enforce verifications (making them optional).
+
 ## Usage and Authentication Workflow
 
 ### Generating an SSL Certificate

--- a/lib/authify/api.rb
+++ b/lib/authify/api.rb
@@ -24,6 +24,9 @@ module Authify
       redis: {
         host: ENV['AUTHIFY_REDIS_HOST'] || 'localhost',
         port: ENV['AUTHIFY_REDIS_PORT'] || '6379'
+      },
+      verifications: {
+        required: ENV['AUTHIFY_VERIFICATIONS_REQUIRED'] == 'false' ? false : true
       }
     )
   end

--- a/lib/authify/api/models/user.rb
+++ b/lib/authify/api/models/user.rb
@@ -83,12 +83,14 @@ module Authify
 
         def self.from_api_key(access, secret)
           key = APIKey.find_by_access_key(access)
-          key.user if key && key.compare_secret(secret) && key.user.verified?
+          verification_truthiness = (key.user.verified? || !CONFIG[:verifications][:required])
+          key.user if key && key.compare_secret(secret) && verification_truthiness
         end
 
         def self.from_email(email, password)
           found_user = Models::User.find_by_email(email)
-          found_user if found_user && found_user.authenticate(password) && found_user.verified?
+          verification_truthiness = (found_user.verified? || !CONFIG[:verifications][:required])
+          found_user if found_user && found_user.authenticate(password) && verification_truthiness
         end
 
         def self.from_identity(provider, uid)

--- a/lib/authify/api/services/registration.rb
+++ b/lib/authify/api/services/registration.rb
@@ -74,7 +74,7 @@ module Authify
           update_current_user new_user
 
           response = { id: new_user.id, email: new_user.email }
-          if new_user.verified?
+          if new_user.verified? || !CONFIG[:verifications][:required]
             response[:verified] = true
             response[:jwt]      = jwt_token(user: new_user)
           else

--- a/lib/authify/api/version.rb
+++ b/lib/authify/api/version.rb
@@ -3,7 +3,7 @@ module Authify
     VERSION = [
       0, # Major
       4, # Minor
-      1  # Patch
+      2  # Patch
     ].join('.')
   end
 end


### PR DESCRIPTION
Providing an optional method to start without requiring (but still allowing) email verification. This addresses #28.