### PR TITLE
Feature: user handles

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,7 +20,7 @@ Metrics/PerceivedComplexity:
   Max: 9
 
 Metrics/BlockLength:
-  Max: 30
+  Max: 35
   Exclude:
     - '*.gemspec'
     - 'lib/authify/api/controllers/*.rb'

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ This will return JSON similar to the following:
 {
   "id": 172,
   "email": "someuser@mycompany.com",
+  "handle": "someuser",
   "verified": false
 }
 ```
@@ -229,6 +230,7 @@ This will return JSON similar to the following:
 {
   "id": 172,
   "email": "someuser@mycompany.com",
+  "handle": "someuser",
   "verified": true,
   "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzUxMiJ9.eyJleHAiOjE0ODY0ODcyODcsImlhdCI6MTQ4NjQ4MzY4NywiaXNzIjoiTXkgQXdlc29tZSBDb21wYW55IEluYy4iLCJzY29wZXMiOlsidXNlcl9hY2Nlc3MiXSwidXNlciI6eyJ1c2VybmFtZSI6ImZvb0BiYXIuY29tIiwidWlkIjoyLCJvcmdhbml6YXRpb25zIjpbXSwiZ3JvdXBzIjpbXX19.AWfPpKX9mP03Djz3-LMneJdEVsXQm_4GOPVCdkfiiBeIR4pVLKTVrNoNdlNgSEkZEeUw1RPsVxpAR7wDgB4cNcYiAP3fNaD8OPyWfOQAV0lTvDUSH3YU39cZAVwvbX9HleOHBLrFGBbui5wSvfi7WZZlH808psiuUAVhBOe7mfrNiHGB"
 }

--- a/db/migrate/20170711151033_add_handle_to_user.rb
+++ b/db/migrate/20170711151033_add_handle_to_user.rb
@@ -1,0 +1,9 @@
+# User handle
+class AddHandleToUser < ActiveRecord::Migration[5.0]
+  def change
+    change_table :users do |t|
+      t.string :handle
+      t.index :handle
+    end
+  end
+end

--- a/db/migrate/20170711151033_add_handle_to_user.rb
+++ b/db/migrate/20170711151033_add_handle_to_user.rb
@@ -1,9 +1,12 @@
 # User handle
 class AddHandleToUser < ActiveRecord::Migration[5.0]
-  def change
-    change_table :users do |t|
-      t.string :handle
-      t.index :handle
-    end
+  def up
+    add_column :users, :handle, :string
+    add_index :users, :handle, unique: true
+  end
+
+  def down
+    remove_index :users, :handle
+    remove_column :users, :handle
   end
 end

--- a/db/migrate/20170712101155_add_unique_index_to_groups.rb
+++ b/db/migrate/20170712101155_add_unique_index_to_groups.rb
@@ -1,0 +1,6 @@
+# Adds a unique index on the group name and org
+class AddUniqueIndexToGroups < ActiveRecord::Migration[5.1]
+  def change
+    add_index :groups, %i[name organization_id], unique: true
+  end
+end

--- a/db/migrate/20170712101438_add_unique_index_to_identities.rb
+++ b/db/migrate/20170712101438_add_unique_index_to_identities.rb
@@ -1,0 +1,6 @@
+# Adding a unique index to identities on uid and provider
+class AddUniqueIndexToIdentities < ActiveRecord::Migration[5.1]
+  def change
+    add_index :identities, %i[uid provider], unique: true
+  end
+end

--- a/db/migrate/20170712103319_add_unique_index_to_organizations.rb
+++ b/db/migrate/20170712103319_add_unique_index_to_organizations.rb
@@ -1,0 +1,6 @@
+# Adding a unique index to name on organizations
+class AddUniqueIndexToOrganizations < ActiveRecord::Migration[5.1]
+  def change
+    add_index :organizations, :name, unique: true, name: :index_organizations_unique_on_name
+  end
+end

--- a/db/migrate/20170712103320_add_unique_index_to_users.rb
+++ b/db/migrate/20170712103320_add_unique_index_to_users.rb
@@ -1,0 +1,6 @@
+# Adding a unique index to email on users
+class AddUniqueIndexToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_index :users, :email, unique: true, name: :index_users_unique_on_email
+  end
+end

--- a/db/migrate/20170714051226_set_default_handle_on_users.rb
+++ b/db/migrate/20170714051226_set_default_handle_on_users.rb
@@ -1,0 +1,16 @@
+# Sets a handle for users without one
+class SetDefaultHandleOnUsers < ActiveRecord::Migration[5.1]
+  def up
+    Authify::API::Models::User.reset_column_information
+    Authify::API::Models::User.all.each do |user|
+      tmp_handle = Authify::API::Models::User.uniq_handle_generator(user.full_name, user.email)
+      user.handle = tmp_handle unless user.handle
+      puts "Setting handle #{user.handle} for User #{user.id}"
+      user.save
+    end
+  end
+
+  def down
+    # nothing to do
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170609181046) do
+ActiveRecord::Schema.define(version: 20170712103320) do
 
   create_table "apikeys", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id"
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 20170609181046) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["name", "organization_id"], name: "index_groups_on_name_and_organization_id", unique: true
     t.index ["name"], name: "index_groups_on_name"
     t.index ["organization_id"], name: "index_groups_on_organization_id"
   end
@@ -46,6 +47,7 @@ ActiveRecord::Schema.define(version: 20170609181046) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["provider"], name: "index_identities_on_provider"
+    t.index ["uid", "provider"], name: "index_identities_on_uid_and_provider", unique: true
     t.index ["uid"], name: "index_identities_on_uid"
     t.index ["user_id"], name: "index_identities_on_user_id"
   end
@@ -70,6 +72,7 @@ ActiveRecord::Schema.define(version: 20170609181046) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_organizations_on_name"
+    t.index ["name"], name: "index_organizations_unique_on_name", unique: true
   end
 
   create_table "trusted_delegates", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -92,8 +95,11 @@ ActiveRecord::Schema.define(version: 20170609181046) do
     t.boolean "admin", default: false, null: false
     t.boolean "verified"
     t.string "verification_token"
+    t.string "handle"
     t.index ["admin"], name: "index_users_on_admin"
     t.index ["email"], name: "index_users_on_email"
+    t.index ["email"], name: "index_users_unique_on_email", unique: true
+    t.index ["handle"], name: "index_users_on_handle", unique: true
     t.index ["verified"], name: "index_users_on_verified"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170712103320) do
+ActiveRecord::Schema.define(version: 20170714051226) do
 
   create_table "apikeys", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id"

--- a/lib/authify/api/controllers/user.rb
+++ b/lib/authify/api/controllers/user.rb
@@ -26,17 +26,18 @@ module Authify
           end
 
           def modifiable_fields
-            %i[full_name email].tap do |a|
+            %i[full_name email handle].tap do |a|
               a << :admin if role.include?(:admin)
             end
           end
 
           def indexable_fields
-            %i[full-name admin apikeys groups organizations identities].tap do |a|
+            %i[full-name admin handle groups organizations identities].tap do |a|
               if role?(:admin) || role?(:myself)
                 a << :verified
                 a << :email
                 a << :'created-at'
+                a << :apikeys
               end
             end
           end

--- a/lib/authify/api/models/group.rb
+++ b/lib/authify/api/models/group.rb
@@ -5,6 +5,8 @@ module Authify
       class Group < ActiveRecord::Base
         include JSONAPIUtils
 
+        validates_uniqueness_of :name, scope: :organization_id
+
         belongs_to :organization,
                    required: true,
                    class_name: 'Authify::API::Models::Organization'

--- a/lib/authify/api/models/identity.rb
+++ b/lib/authify/api/models/identity.rb
@@ -5,6 +5,8 @@ module Authify
       class Identity < ActiveRecord::Base
         include JSONAPIUtils
 
+        validates_uniqueness_of :uid, scope: :provider
+
         belongs_to :user,
                    required: true,
                    class_name: 'Authify::API::Models::User'

--- a/lib/authify/api/models/organization.rb
+++ b/lib/authify/api/models/organization.rb
@@ -5,6 +5,8 @@ module Authify
       class Organization < ActiveRecord::Base
         include JSONAPIUtils
 
+        validates_uniqueness_of :name
+
         has_many :organization_memberships,
                  class_name: 'Authify::API::Models::OrganizationMembership',
                  dependent: :destroy

--- a/lib/authify/api/models/user.rb
+++ b/lib/authify/api/models/user.rb
@@ -10,6 +10,7 @@ module Authify
         attr_reader :password
 
         validates_uniqueness_of :email
+        validates_uniqueness_of :handle
         validates_format_of :email, with: /[-a-z0-9_+\.+]+\@([-a-z0-9]+\.)+[a-z0-9]{2,4}/i
 
         has_many :apikeys,

--- a/lib/authify/api/models/user.rb
+++ b/lib/authify/api/models/user.rb
@@ -33,8 +33,9 @@ module Authify
 
         # Encrypts the password into the password_digest attribute.
         def password=(plain_password)
+          return false unless viable(plain_password)
           @password = plain_password
-          self.password_digest = salted_sha512(plain_password) if viable(plain_password)
+          self.password_digest = salted_sha512(plain_password)
         end
 
         def authenticate(unencrypted_password)
@@ -98,10 +99,26 @@ module Authify
           provided_identity.user if provided_identity
         end
 
+        def self.uniq_handle_generator(name, email)
+          possibilities = [email.split('@').first.downcase.gsub(/[._-]/, '')]
+          possibilities << name.downcase.gsub(/[.-]/, '_') if name && !name.empty?
+          possibilities.each do |possibility|
+            return possibility unless find_by_handle(possibility)
+          end
+          100.times do
+            possibilities.each do |possibility|
+              rando_num = rand(9999)
+              attempt   = "#{possibility.downcase.gsub(/[.-]/, '_')}#{rando_num}"
+              return attempt unless find_by_handle(attempt)
+            end
+          end
+          false # didn't work if we got here
+        end
+
         private
 
         def viable(string)
-          string && !string.empty?
+          string && !string.empty? && string.length >= 8
         end
       end
     end

--- a/lib/authify/api/serializers/user_serializer.rb
+++ b/lib/authify/api/serializers/user_serializer.rb
@@ -10,6 +10,7 @@ module Authify
         attribute :admin
         attribute :created_at
         attribute :verified
+        attribute :handle
 
         has_many :apikeys
         has_many :groups

--- a/lib/authify/api/version.rb
+++ b/lib/authify/api/version.rb
@@ -2,8 +2,8 @@ module Authify
   module API
     VERSION = [
       0, # Major
-      4, # Minor
-      3  # Patch
+      5, # Minor
+      0  # Patch
     ].join('.')
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,7 +69,8 @@ RSpec.configure do |config|
     # A pre-built user for testing
     user = Authify::API::Models::User.new(
       email: 'test.user@example.com',
-      full_name: 'Test User'
+      full_name: 'Test User',
+      handle: 'testuser'
     )
     user.password = 'testuser123'
     user.save
@@ -90,7 +91,8 @@ RSpec.configure do |config|
     # A pre-built user for misbehaving
     bad_user = Authify::API::Models::User.new(
       email: 'bad.user@example.com',
-      full_name: 'Bad User'
+      full_name: 'Bad User',
+      handle: 'baduser'
     )
     bad_user.password = 'baduser123'
     bad_user.save
@@ -100,6 +102,7 @@ RSpec.configure do |config|
     admin_user = Authify::API::Models::User.new(
       email: 'admin.user@example.com',
       full_name: 'Admin User',
+      handle: 'admin',
       admin: true
     )
     admin_user.password = 'adminuser123'


### PR DESCRIPTION
This makes Authify less inclined to expose email addresses directly, instead favoring users' `#handle` attribute. The intention is to use this similarly to typical @ mentions in other applications in lieu of having to know or making available publicly the email addresses of other users.

This also includes a version bump. Additionally, I snuck in some performance improvements (better indexes in the DB), some validations for fields that should be unique, and some slightly stricter handling of user passwords (they now need to be at least 8 characters long).